### PR TITLE
FakeItEasy for some tests

### DIFF
--- a/Tests/BookTests/QueryTest/GetByAuthorId/GetBooksByAuthorIdTests.cs
+++ b/Tests/BookTests/QueryTest/GetByAuthorId/GetBooksByAuthorIdTests.cs
@@ -1,56 +1,62 @@
-﻿using Infrastructure.Data;
-using Application.Queries.Books;
+﻿using Application.Queries.Books;
 using Domain;
-using Infrastructure.Repository;
-using Tests.MemoryDatabase;
+using Application.Interfaces.RepositoryInterfaces;
+using FakeItEasy;
 
 namespace Tests.BookTests.QueryTest.GetByAuthorId
 {
     public class GetBooksByAuthorIdTests
     {
-        private GetBooksByAuthorIdQueryHandler _handler;
-        private RealDatabase _db;
-
-        public GetBooksByAuthorIdTests()
-        {
-            _db = CreateTestDb.CreateInMemoryTestDbWithData();
-            _handler = new GetBooksByAuthorIdQueryHandler(new BookRepository(_db));
-        }
-
         [Fact]
         public async Task ValidId_ReturnsCorrectBooks()
         {
             // Arrange
-            var AuthorId = new Guid("12345678-1234-5678-1234-a00000000000");
+            var authorId = Guid.NewGuid();
+            var testBooks = new List<Book>
+            {
+                new Book { Id = Guid.NewGuid(), Title = "Book Part 1", AuthorId = authorId },
+                new Book { Id = Guid.NewGuid(), Title = "Book Part 2", AuthorId = authorId },
+                new Book { Id = Guid.NewGuid(), Title = "Book Part 3", AuthorId = authorId },
+            };
 
-            var query = new GetBooksByAuthorIdQuery(AuthorId);
+            // Create fake repository that return the test books
+            var fakeRepository = A.Fake<IBookRepository>();
+            A.CallTo(() => fakeRepository.GetAllByAuthor(authorId))
+                .Returns(OperationResult<List<Book>>.Successful(testBooks));
+
+            var handler = new GetBooksByAuthorIdQueryHandler(fakeRepository);
+            var query = new GetBooksByAuthorIdQuery(authorId);
 
             // Act
-            var operationResult = await _handler.Handle(query, CancellationToken.None);
+            var operationResult = await handler.Handle(query, CancellationToken.None);
 
             // Assert
             Assert.True(operationResult.IsSuccessful);
             var result = operationResult.Data;
             Assert.NotNull(result);
-            Assert.Equal(2, result.Count);
-            Assert.Equal(AuthorId, result[0].AuthorId);
-            Assert.Equal(AuthorId, result[1].AuthorId);
-            Assert.NotEqual(result[0].Id, result[1].Id);
+            Assert.Equal(result, testBooks);
         }
 
         [Fact]
-        public async Task InvalidId_Failure()
+        public async Task InvalidId_KeyNotFound()
         {
             // Arrange
             var invalidAuthorId = Guid.NewGuid();
 
+            // Create fake repository that return key not found
+            var fakeRepository = A.Fake<IBookRepository>();
+            A.CallTo(() => fakeRepository.GetAllByAuthor(invalidAuthorId))
+                .Returns(OperationResult<List<Book>>.KeyNotFound(invalidAuthorId));
+
+            var handler = new GetBooksByAuthorIdQueryHandler(fakeRepository);
             var query = new GetBooksByAuthorIdQuery(invalidAuthorId);
 
             // Act
-            var operationResult = await _handler.Handle(query, CancellationToken.None);
+            var operationResult = await handler.Handle(query, CancellationToken.None);
 
             // Assert
             Assert.False(operationResult.IsSuccessful);
+            Assert.True(operationResult.IsKeyNotFound);
         }
     }
 }


### PR DESCRIPTION
Used FakeItEasy to test that GetBookById and GetBooksByAuthorId uses IBookRespository Used FakeItEasy in UpdateBookTests test InvalidTitleCheckedInHandler_ReturnFailureEvenIfFakeItEasyRepositoryReturnSuccess() to test that the handler checks basic argument correctness (that title isn't empty)